### PR TITLE
Added SSL_VERIFY flag.

### DIFF
--- a/googlesearch/__init__.py
+++ b/googlesearch/__init__.py
@@ -6,7 +6,7 @@ from .user_agents import get_useragent
 import urllib
 
 
-def _req(term, results, lang, start, proxies, timeout):
+def _req(term, results, lang, start, proxies, timeout, SSL_VERIFY):
     resp = get(
         url="https://www.google.com/search",
         headers={
@@ -20,6 +20,7 @@ def _req(term, results, lang, start, proxies, timeout):
         },
         proxies=proxies,
         timeout=timeout,
+        verify=SSL_VERIFY,
     )
     resp.raise_for_status()
     return resp
@@ -35,7 +36,7 @@ class SearchResult:
         return f"SearchResult(url={self.url}, title={self.title}, description={self.description})"
 
 
-def search(term, num_results=10, lang="en", proxy=None, advanced=False, sleep_interval=0, timeout=5):
+def search(term, num_results=10, lang="en", proxy=None, advanced=False, sleep_interval=0, timeout=5, SSL_VERIFY=None):
     """Search the Google search engine"""
 
     escaped_term = urllib.parse.quote_plus(term) # make 'site:xxx.xxx.xxx ' works.
@@ -53,7 +54,7 @@ def search(term, num_results=10, lang="en", proxy=None, advanced=False, sleep_in
     while start < num_results:
         # Send request
         resp = _req(escaped_term, num_results - start,
-                    lang, start, proxies, timeout)
+                    lang, start, proxies, timeout, SSL_VERIFY)
 
         # Parse
         soup = BeautifulSoup(resp.text, "html.parser")


### PR DESCRIPTION
Added SSL_VERIFY flag as with some of the proxy providers it throws SSL errors like below:

(Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1129)')))

This flag will take "True" or "False" or path-to-ca.crt file.

It helps with not installing and configuring the Proxy CA cert.